### PR TITLE
Tidied up download and pkg recipes. Re-tabbed

### DIFF
--- a/EndNote/EndNoteX7.download.recipe
+++ b/EndNote/EndNoteX7.download.recipe
@@ -2,49 +2,47 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the latest full installer of EndNote X7.</string>
-	<key>Identifier</key>
-	<string>com.github.jbaker10.download.EndNoteX7</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>EndNote X7</string>
-		<key>version</key>
-		<string>latest</string>
-		<key>DOWNLOAD_URL</key>
-		<string>http://download.endnote.com/downloads/X7/EndNoteX7Installer.dmg</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.5.0</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%/EndNote X7.app</string>
-				<key>requirement</key>
-				<string>anchor trusted</string>
-			</dict>
-		</dict>
-	</array>
+  <key>Description</key>
+  <string>Downloads the latest full installer of EndNote X7.</string>
+  <key>Identifier</key>
+  <string>com.github.jbaker10.download.EndNoteX7</string>
+  <key>Input</key>
+  <dict>
+    <key>NAME</key>
+    <string>EndNote_X7</string>
+    <key>DOWNLOAD_URL</key>
+    <string>http://download.endnote.com/downloads/X7/EndNoteX7Installer.dmg</string>
+  </dict>
+  <key>MinimumVersion</key>
+  <string>0.6.1</string>
+  <key>Process</key>
+  <array>
+    <dict>
+      <key>Processor</key>
+      <string>URLDownloader</string>
+      <key>Arguments</key>
+      <dict>
+        <key>url</key>
+        <string>%DOWNLOAD_URL%</string>
+        <key>CHECK_FILESIZE_ONLY</key>
+        <true/>
+      </dict>
+    </dict>
+    <dict>
+      <key>Processor</key>
+      <string>EndOfCheckPhase</string>
+    </dict>
+    <dict>
+      <key>Processor</key>
+      <string>CodeSignatureVerifier</string>
+      <key>Arguments</key>
+      <dict>
+        <key>input_path</key>
+        <string>%pathname%/EndNote X7/EndNote X7.app</string>
+        <key>requirement</key>
+        <string>anchor trusted</string>
+      </dict>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/EndNote/EndNoteX7.pkg.recipe
+++ b/EndNote/EndNoteX7.pkg.recipe
@@ -2,86 +2,84 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the latest full installer of EndNote X7 and builds an Apple installer pkg.</string>
-    <key>Identifier</key>
-    <string>com.github.jbaker10.pkg.EndNoteX7</string>
-    <key>Input</key>
+  <key>Description</key>
+  <string>Downloads the latest full installer of EndNote X7 and builds an Apple installer pkg.</string>
+  <key>Identifier</key>
+  <string>com.github.jbaker10.pkg.EndNoteX7</string>
+  <key>Input</key>
+  <dict>
+    <key>NAME</key>
+    <string>EndNote_X7</string>
+    <key>PKG_ID</key>
+    <string>com.company.EndNote</string>
+  </dict>
+  <key>ParentRecipe</key>
+  <string>com.github.jbaker10.download.EndNoteX7</string>
+  <key>Process</key>
+  <array>
     <dict>
-        <key>NAME</key>
-        <string>EndNote X7</string>
-        <key>app_name</key>
-        <string>EndNote X7.app</string>
+      <key>Processor</key>
+      <string>Versioner</string>
+      <key>Arguments</key>
+      <dict>
+        <key>input_plist_path</key>
+        <string>%pathname%/Endnote X7/EndNote X7.app/Contents/Info.plist</string>
+      </dict>
     </dict>
-    <key>ParentRecipe</key>
-    <string>com.github.jbaker10.download.EndNoteX7</string>
-    <key>Process</key>
-    <array>
+    <dict>
+      <key>Processor</key>
+      <string>PkgRootCreator</string>
+      <key>Arguments</key>
+      <dict>
+        <key>pkgroot</key>
+        <string>%RECIPE_CACHE_DIR%/%NAME%/pkg</string>
+        <key>pkgdirs</key>
         <dict>
-            <key>Processor</key>
-            <string>AppDmgVersioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>dmg_path</key>
-                <string>%pathname%</string>
-                <key>dmg_path</key>
-                <string>%pathname%/%NAME%</string>
-            </dict>
+          <key>Applications</key>
+          <string>0775</string>
         </dict>
+      </dict>
+    </dict>
+    <dict>
+      <key>Processor</key>
+      <string>Copier</string>
+      <key>Arguments</key>
+      <dict>
+        <key>source_path</key>
+        <string>%pathname%/EndNote X7</string>
+        <key>destination_path</key>
+        <string>%pkgroot%/Applications/EndNote X7</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>Processor</key>
+      <string>PkgCreator</string>
+      <key>Arguments</key>
+      <dict>
+        <key>pkg_request</key>
         <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
+          <key>pkgname</key>
+          <string>%NAME%-%version%</string>
+          <key>version</key>
+          <string>%version%</string>
+          <key>id</key>
+          <string>%PKG_ID%</string>
+          <key>options</key>
+          <string>purge_ds_store</string>
+          <key>chown</key>
+          <array>
             <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/pkg</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
+              <key>path</key>
+              <string>Applications</string>
+              <key>user</key>
+              <string>root</string>
+              <key>group</key>
+              <string>admin</string>
             </dict>
+          </array>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%pathname%/%NAME%</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                    <key>id</key>
-                    <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
-        </dict>
-    </array>
+      </dict>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/EndNote/EndNoteX7.pkg.recipe
+++ b/EndNote/EndNoteX7.pkg.recipe
@@ -13,6 +13,8 @@
     <key>PKG_ID</key>
     <string>com.company.EndNote</string>
   </dict>
+  <key>MinimumVersion</key>
+  <string>0.6.1</string>
   <key>ParentRecipe</key>
   <string>com.github.jbaker10.download.EndNoteX7</string>
   <key>Process</key>


### PR DESCRIPTION
Hi there,

I've been through these recipes and corrected a few things - they weren't currently working for a couple of reasons. I also retabbed the files with 2 space indents as one was tabbed and the other was spaced. Unfortunately this makes the diff a bit hard to read so to summarise:

1) I've removed references to the `%NAME%` var in your recipes where overriding that variable could break functionality. `%NAME%` shouldn't really be used where you know the path you are expecting, as if someone changes it in the override the recipe will b0rk. So I cleaned up some of the paths too where you'd used `%NAME%` too.

2) Bumped the `MinimumVersion` to `0.6.1` and added a `CHECK_FILESIZE_ONLY` key. This stops the download recipe repeatedly downloading the same file if the filesize is the same. Unfortunately for some reason the etag changes every time.

3) Removed the setting of `%version%` to `latest` in the download recipe - it didn't look like you were using this anywhere

4) Added a `PKG_ID` variable in the `Input` of the pkg recipe and used that as the value for `id` in the pkgrequest. This should be overridable by the user, and what you had there previously `%bundleid%` wasn't referenced anywhere so was breaking the recipe.

It's possible that it would be a good idea to have a postinstall for this pkg too which copied the CWYW stuff to the right directories. I'm not sure if this should be left to the admin or not. I may have a look at the update recipes soon, but the full install recipes are enough for me right now
