### PR TITLE
fixing osquery download recipe

### DIFF
--- a/osquery/osquery.download.recipe
+++ b/osquery/osquery.download.recipe
@@ -23,12 +23,19 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://osquery.io/downloads/</string>
+				<string>https://github.com/facebook/osquery/releases/latest</string>
 				<key>re_pattern</key>
-				<string>&lt;a href="(?P&lt;url&gt;https://.*/osquery.*\.pkg)"&gt;</string>
+				<string>Release ([\d\.]+)</string>
+				<key>result_output_var_name</key>
+				<string>ver</string>
 			</dict>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://osquery-packages.s3.amazonaws.com/darwin/osquery-%ver%.pkg</string>
+			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>


### PR DESCRIPTION
The current osquery download recipe stopped working, I believe due to the recent website redesign. The changes here have URLTextSearcher look for the latest non pre-release version, then uses that version to pull the proper package from the osquery AWS instance. 

#### recipe run output

```
Processing ./osquery.download.recipe...
WARNING: ./osquery.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': u'Release ([\\d\\.]+)',
           'result_output_var_name': u'ver',
           'url': u'https://github.com/facebook/osquery/releases/latest'}}
URLTextSearcher: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
URLTextSearcher: Found matching text (ver): 2.11.2
{'Output': {u'ver': '2.11.2'}}
URLDownloader
{'Input': {'CURL_PATH': '/usr/bin/curl',
           'filename': u'osquery-2.11.2.pkg',
           'url': u'https://osquery-packages.s3.amazonaws.com/darwin/osquery-2.11.2.pkg'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 31 Dec 2017 02:26:47 GMT
URLDownloader: Storing new ETag header: "382adfe5fa70f8e8d84548b155f48cda"
URLDownloader: Downloaded /Users/wes/Library/AutoPkg/Cache/com.github.jbaker10.download.osquery/downloads/osquery-2.11.2.pkg
{'Output': {'download_changed': True,
            'etag': '"382adfe5fa70f8e8d84548b155f48cda"',
            'last_modified': 'Sun, 31 Dec 2017 02:26:47 GMT',
            'pathname': u'/Users/wes/Library/AutoPkg/Cache/com.github.jbaker10.download.osquery/downloads/osquery-2.11.2.pkg',
            'url_downloader_summary_result': {'data': {'download_path': u'/Users/wes/Library/AutoPkg/Cache/com.github.jbaker10.download.osquery/downloads/osquery-2.11.2.pkg'},
                                              'summary_text': 'The following new items were downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': (
    "Developer ID Installer: Theodore Reed (B89LNTUADM)",
    "Developer ID Certification Authority",
    "Apple Root CA"
),
           'input_path': u'/Users/wes/Library/AutoPkg/Cache/com.github.jbaker10.download.osquery/downloads/osquery-2.11.2.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "osquery-2.11.2.pkg":
CodeSignatureVerifier:    Status: signed by a certificate trusted by Mac OS X
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Theodore Reed (B89LNTUADM)
CodeSignatureVerifier:        SHA1 fingerprint: 77 19 1E 49 10 ED 81 EC C1 80 52 D6 7E EB 3C 2E EF D6 72 7E
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/wes/Library/AutoPkg/Cache/com.github.jbaker10.download.osquery/receipts/osquery.download-receipt-20180309-101644.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/wes/Library/AutoPkg/Cache/com.github.jbaker10.download.osquery/downloads/osquery-2.11.2.pkg
```