### PR TITLE
Update ESETEndpointAntiVirus.pkg.recipe

### DIFF
--- a/ESET/ESETEndpointAntiVirus.pkg.recipe
+++ b/ESET/ESETEndpointAntiVirus.pkg.recipe
@@ -15,6 +15,15 @@
     <string>com.github.jbaker10.download.ESETEndpointAntiVirus</string>
     <key>Process</key>
     <array>
+		<dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Resources/Uninstaller.app/Contents/Info.plist</string>
+            </dict>
+        </dict>        
         <dict>
             <key>Processor</key>
             <string>Copier</string>
@@ -23,7 +32,7 @@
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Resources/Installer.pkg</string>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Added Versioner processor to extract version number from the DMG/Resources/Uninstaller.app and append it to the resulting package filename - the uninstaller app version the same as the product itself.