### PR TITLE
Rework of malfunctioning osquery download recipe

### DIFF
--- a/osquery/osquery.download.recipe
+++ b/osquery/osquery.download.recipe
@@ -18,23 +18,10 @@
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://github.com/facebook/osquery/releases/latest</string>
-                <key>re_pattern</key>
-                <string>Release ([\d\.]+)</string>
-                <key>result_output_var_name</key>
-                <string>ver</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://osquery-packages.s3.amazonaws.com/darwin/osquery-%ver%.pkg</string>
+                <string>https://pkg.osquery.io/darwin/osquery.pkg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
The extraction of the download link was not possible anymore because the latest release is a windows only release.
The latest version still can be downloaded by removing the version from the download link.