### PR TITLE
Update ESETEndpointAntiVirus.munki.recipe

### DIFF
--- a/ESET/ESETEndpointAntiVirus.munki.recipe
+++ b/ESET/ESETEndpointAntiVirus.munki.recipe
@@ -33,20 +33,130 @@
     <key>MinimumVersion</key>
     <string>0.6.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.jbaker10.pkg.ESETEndpointAntiVirus</string>
+    <string>com.github.jbaker10.download.ESETEndpointAntiVirus</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>Copier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Resources/Installer.pkg</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+                <key>flat_pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>Applications</key>
+                    <string>0755</string>
+                </dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%pkgroot%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/esetendpointantivirus.pkg/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%pkgroot%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/ESET Endpoint Antivirus.app</string>
+                </array>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%pkgroot%/Applications/ESET Endpoint Antivirus.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>minimum_os_version</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%minimum_os_version%</string>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>munkiimport_pkgname</key>
-                <string>%MAKEPKGINFO_PKGNAME%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/pkgroot/</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack/</string>
+                </array>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Amended recipe to build and installs array from the .app on disk, changed parent to .downland, and changed to pull not only versioning info but min os version from the info.plist.

```
Processing /Users/ben/Git/other-recipes/jbaker10-recipes/ESET/ESETEndpointAntiVirus.munki.recipe...
WARNING: /Users/ben/Git/other-recipes/jbaker10-recipes/ESET/ESETEndpointAntiVirus.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Use of undefined key in variable substitution: 'RECIPE_CACHE_DIR'
URLDownloader
{'Input': {'filename': 'ESET Endpoint Anti-Virus.dmg',
           'url': 'https://download.eset.com/com/eset/apps/business/eea/mac/latest/eea_osx_en.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/downloads/ESET Endpoint Anti-Virus.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/downloads/ESET '
                        'Endpoint Anti-Virus.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: ESET, spol. s '
                                        'r.o. (P8DQRXPVLP)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/downloads/ESET '
                         'Endpoint Anti-Virus.dmg/Resources/Installer.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/downloads/ESET Endpoint Anti-Virus.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Installer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-04-09 08:38:14 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: ESET, spol. s r.o. (P8DQRXPVLP)
CodeSignatureVerifier:        Expires: 2022-03-04 12:30:28 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            47 74 C2 5F 53 75 E2 FD 3F 68 12 D1 86 F2 50 59 DE 40 28 92 B9 6C
CodeSignatureVerifier:            1C 6A 66 32 21 4C F0 BD F4 48
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/ESET '
                               'Endpoint Anti-Virus.pkg',
           'source_path': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/downloads/ESET '
                          'Endpoint Anti-Virus.dmg/Resources/Installer.pkg'}}
Copier: Parsed dmg results: dmg_path: /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/downloads/ESET Endpoint Anti-Virus.dmg, dmg: .dmg/, dmg_source_path: Resources/Installer.pkg
Copier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/downloads/ESET Endpoint Anti-Virus.dmg
Copier: Copied /private/tmp/dmg.4EaQuv/Resources/Installer.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/ESET Endpoint Anti-Virus.pkg
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/ESET '
                            'Endpoint Anti-Virus.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/ESET Endpoint Anti-Virus.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/unpack/esetendpointantivirus.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/unpack/esetendpointantivirus.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot',
           'installs_item_paths': ['/Applications/ESET Endpoint Antivirus.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/ESET Endpoint Antivirus.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.eset.eea.6',
                                                 'CFBundleName': 'ESET '
                                                                 'Endpoint '
                                                                 'Antivirus',
                                                 'CFBundleShortVersionString': '6.10.910.0',
                                                 'CFBundleVersion': '6100.91.00f01',
                                                 'minosversion': '10.9',
                                                 'path': '/Applications/ESET '
                                                         'Endpoint '
                                                         'Antivirus.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.eset.eea.6',
                                                'CFBundleName': 'ESET Endpoint '
                                                                'Antivirus',
                                                'CFBundleShortVersionString': '6.10.910.0',
                                                'CFBundleVersion': '6100.91.00f01',
                                                'minosversion': '10.9',
                                                'path': '/Applications/ESET '
                                                        'Endpoint '
                                                        'Antivirus.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Light-footprint security against '
                                      'spyware, viruses and cross-platform '
                                      'infections.',
                       'display_name': 'ESET Endpoint Anti-Virus',
                       'name': 'ESET Endpoint Anti-Virus',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.eset.eea.6', 'CFBundleName': 'ESET Endpoint Antivirus', 'CFBundleShortVersionString': '6.10.910.0', 'CFBundleVersion': '6100.91.00f01', 'minosversion': '10.9', 'path': '/Applications/ESET Endpoint Antivirus.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'Light-footprint security against '
                                       'spyware, viruses and cross-platform '
                                       'infections.',
                        'display_name': 'ESET Endpoint Anti-Virus',
                        'installs': [{'CFBundleIdentifier': 'com.eset.eea.6',
                                      'CFBundleName': 'ESET Endpoint Antivirus',
                                      'CFBundleShortVersionString': '6.10.910.0',
                                      'CFBundleVersion': '6100.91.00f01',
                                      'minosversion': '10.9',
                                      'path': '/Applications/ESET Endpoint '
                                              'Antivirus.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'ESET Endpoint Anti-Virus',
                        'unattended_install': True}}}
PlistReader
{'Input': {'info_path': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot/Applications/ESET '
                        'Endpoint Antivirus.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version',
                          'LSMinimumSystemVersion': 'minimum_os_version'}}}
PlistReader: Reading: /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot/Applications/ESET Endpoint Antivirus.app/Contents/Info.plist
PlistReader: Assigning value of '6.10.910.0' to output variable 'version'
PlistReader: Assigning value of '10.9' to output variable 'minimum_os_version'
{'Output': {'plist_reader_output_variables': {'minimum_os_version': '10.9',
                                              'version': '6.10.910.0'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'minimum_os_version': '10.9',
                                  'version': '6.10.910.0'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Light-footprint security against '
                                      'spyware, viruses and cross-platform '
                                      'infections.',
                       'display_name': 'ESET Endpoint Anti-Virus',
                       'installs': [{'CFBundleIdentifier': 'com.eset.eea.6',
                                     'CFBundleName': 'ESET Endpoint Antivirus',
                                     'CFBundleShortVersionString': '6.10.910.0',
                                     'CFBundleVersion': '6100.91.00f01',
                                     'minosversion': '10.9',
                                     'path': '/Applications/ESET Endpoint '
                                             'Antivirus.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'ESET Endpoint Anti-Virus',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'minimum_os_version': '10.9', 'version': '6.10.910.0'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'Light-footprint security against '
                                       'spyware, viruses and cross-platform '
                                       'infections.',
                        'display_name': 'ESET Endpoint Anti-Virus',
                        'installs': [{'CFBundleIdentifier': 'com.eset.eea.6',
                                      'CFBundleName': 'ESET Endpoint Antivirus',
                                      'CFBundleShortVersionString': '6.10.910.0',
                                      'CFBundleVersion': '6100.91.00f01',
                                      'minosversion': '10.9',
                                      'path': '/Applications/ESET Endpoint '
                                              'Antivirus.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.9',
                        'name': 'ESET Endpoint Anti-Virus',
                        'unattended_install': True,
                        'version': '6.10.910.0'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/ESET '
                       'Endpoint Anti-Virus.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Light-footprint security against '
                                      'spyware, viruses and cross-platform '
                                      'infections.',
                       'display_name': 'ESET Endpoint Anti-Virus',
                       'installs': [{'CFBundleIdentifier': 'com.eset.eea.6',
                                     'CFBundleName': 'ESET Endpoint Antivirus',
                                     'CFBundleShortVersionString': '6.10.910.0',
                                     'CFBundleVersion': '6100.91.00f01',
                                     'minosversion': '10.9',
                                     'path': '/Applications/ESET Endpoint '
                                             'Antivirus.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.9',
                       'name': 'ESET Endpoint Anti-Virus',
                       'unattended_install': True,
                       'version': '6.10.910.0'},
           'repo_subdirectory': 'security',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/security/ESET Endpoint Anti-Virus-6.10.910.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/security/ESET Endpoint Anti-Virus-6.10.910.0__1.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'ESET Endpoint '
                                                               'Anti-Virus',
                                                       'pkg_repo_path': 'security/ESET '
                                                                        'Endpoint '
                                                                        'Anti-Virus-6.10.910.0__1.pkg',
                                                       'pkginfo_path': 'security/ESET '
                                                                       'Endpoint '
                                                                       'Anti-Virus-6.10.910.0__1.plist',
                                                       'version': '6.10.910.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 7, 10, 13, 29, 2),
                                         'munki_version': '5.5.0.4360',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'Light-footprint security against '
                                          'spyware, viruses and cross-platform '
                                          'infections.',
                           'display_name': 'ESET Endpoint Anti-Virus',
                           'installed_size': 143198,
                           'installer_item_hash': '2c143796ae247e92e96949791b8356bafaa2abd9b94691672c494b135b62fc31',
                           'installer_item_location': 'security/ESET Endpoint '
                                                      'Anti-Virus-6.10.910.0__1.pkg',
                           'installer_item_size': 129377,
                           'installs': [{'CFBundleIdentifier': 'com.eset.eea.6',
                                         'CFBundleName': 'ESET Endpoint '
                                                         'Antivirus',
                                         'CFBundleShortVersionString': '6.10.910.0',
                                         'CFBundleVersion': '6100.91.00f01',
                                         'minosversion': '10.9',
                                         'path': '/Applications/ESET Endpoint '
                                                 'Antivirus.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.9',
                           'name': 'ESET Endpoint Anti-Virus',
                           'receipts': [{'installed_size': 1,
                                         'packageid': 'com.eset.esetEndpointAntivirus.pkgid2.pkg',
                                         'version': '0'},
                                        {'installed_size': 4,
                                         'packageid': 'com.eset.esetEndpointAntivirus.GUI_startup.pkg',
                                         'version': '0'},
                                        {'installed_size': 1,
                                         'packageid': 'com.eset.esetEndpointAntivirus.com.eset.esets_gui.pkg',
                                         'version': '0'},
                                        {'installed_size': 1,
                                         'packageid': 'com.eset.esetEndpointAntivirus.com.eset.esets_daemon.pkg',
                                         'version': '0'},
                                        {'installed_size': 143191,
                                         'packageid': 'com.eset.esetEndpointAntivirus.ESETEndpointAntivirus.pkg',
                                         'version': '0'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '6.10.910.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/security/ESET '
                             'Endpoint Anti-Virus-6.10.910.0__1.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/security/ESET '
                                 'Endpoint Anti-Virus-6.10.910.0__1.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/unpack/']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/pkgroot/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/unpack/
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.jbaker10.munki.ESETEndpointAntiVirus/receipts/ESETEndpointAntiVirus.munki-receipt-20210710-142903.plist

The following new items were imported into Munki:
    Name                      Version     Catalogs  Pkginfo Path                                           Pkg Repo Path                                        Icon Repo Path
    ----                      -------     --------  ------------                                           -------------                                        --------------
    ESET Endpoint Anti-Virus  6.10.910.0  testing   security/ESET Endpoint Anti-Virus-6.10.910.0__1.plist  security/ESET Endpoint Anti-Virus-6.10.910.0__1.pkg
```