### PR TITLE
Use Osquery Foundation certificate

### DIFF
--- a/osquery/osquery.download.recipe
+++ b/osquery/osquery.download.recipe
@@ -50,7 +50,7 @@
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Theodore Reed (B89LNTUADM)</string>
+                    <string>Developer ID Installer: OSQUERY A Series of LF Projects, LLC (3522FA9PXF)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
As of [5.0.1](https://github.com/osquery/osquery/releases/tag/5.0.1), osquery releases are signed by the Osquery Foundation.