### PR TITLE
switched to GitHubReleasesInfoProvider

### DIFF
--- a/osquery/osquery.download.recipe
+++ b/osquery/osquery.download.recipe
@@ -3,39 +3,28 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest osquery installer .pkg from the osquery.io/downloads page</string>
+    <string>Downloads the latest osquery installer .pkg from GitHub.</string>
     <key>Identifier</key>
     <string>com.github.jbaker10.download.osquery</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>osquery</string>
-        <key>version</key>
-        <string>latest</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.1</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
+            <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>https://github.com/facebook/osquery/releases/latest</string>
-                <key>re_pattern</key>
-                <string>Release ([\d\.]+)</string>
-                <key>result_output_var_name</key>
-                <string>ver</string>
+                <key>github_repo</key>
+                <string>osquery/osquery</string>
             </dict>
         </dict>
         <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://osquery-packages.s3.amazonaws.com/darwin/osquery-%ver%.pkg</string>
-            </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
         </dict>

--- a/osquery/osquery.download.recipe
+++ b/osquery/osquery.download.recipe
@@ -29,8 +29,6 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
-            <key>Arguments</key>
-            <dict/>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>

--- a/osquery/osquery.download.recipe
+++ b/osquery/osquery.download.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>NAME</key>
         <string>osquery</string>
+        <key>REPO</key>
+        <string>osquery/osquery</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.5.0</string>
@@ -21,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>github_repo</key>
-                <string>osquery/osquery</string>
+                <string>%REPO%</string>
             </dict>
         </dict>
         <dict>

--- a/osquery/osquery.download.recipe
+++ b/osquery/osquery.download.recipe
@@ -2,53 +2,55 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the latest osquery installer .pkg from GitHub.</string>
-    <key>Identifier</key>
-    <string>com.github.jbaker10.download.osquery</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>osquery</string>
-        <key>REPO</key>
-        <string>osquery/osquery</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.5.0</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>GitHubReleasesInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>github_repo</key>
-                <string>%REPO%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: OSQUERY A Series of LF Projects, LLC (3522FA9PXF)</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
-                <key>input_path</key>
-                <string>%pathname%</string>
-            </dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-        </dict>
-    </array>
+	<key>Description</key>
+	<string>Downloads the latest osquery installer .pkg from GitHub.</string>
+	<key>Identifier</key>
+	<string>com.github.jbaker10.download.osquery</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>osquery</string>
+		<key>REPO</key>
+		<string>osquery/osquery</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.5.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>asset_regex</key>
+				<string>.*\.pkg</string>
+				<key>github_repo</key>
+				<string>%REPO%</string>
+			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: OSQUERY A Series of LF Projects, LLC (3522FA9PXF)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/osquery/osquery.munki.recipe
+++ b/osquery/osquery.munki.recipe
@@ -2,47 +2,49 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Identifier</key>
-    <string>com.github.jbaker10.munki.osquery</string>
-    <key>Input</key>
-    <dict>
-        <key>MUNKI_REPO_SUBDIR</key>
-        <string>utilities/osquery</string>
-        <key>NAME</key>
-        <string>osquery</string>
-        <key>pkginfo</key>
-        <dict>
-            <key>catalogs</key>
-            <array>
-                <string>testing</string>
-            </array>
-            <key>category</key>
-            <string>Utilities</string>
-            <key>description</key>
-            <string>osquery allows you to easily ask questions about your Linux and OSX infrastructure. Whether your goal is intrusion detection, infrastructure reliability, or compliance, osquery gives you the ability to empower and inform a broad set of organizations within your company.</string>
-            <key>developer</key>
-            <string>Facebook</string>
-            <key>name</key>
-            <string>%NAME%</string>
-            <key>unattended_install</key>
-            <true/>
-        </dict>
-    </dict>
-    <key>ParentRecipe</key>
-    <string>com.github.jbaker10.download.osquery</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%pathname%</string>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-        </dict>
-    </array>
+	<key>Identifier</key>
+	<string>com.github.jbaker10.munki.osquery</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>utilities/osquery</string>
+		<key>NAME</key>
+		<string>osquery</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>Utilities</string>
+			<key>description</key>
+			<string>osquery is an operating system instrumentation framework for Windows, macOS, and Linux. The tools make low-level operating system analytics and monitoring both performant and intuitive.
+
+osquery exposes an operating system as a high-performance relational database. This allows you to write SQL queries to explore operating system data. With osquery, SQL tables represent abstract concepts such as running processes, loaded kernel modules, open network connections, browser plugins, hardware events or file hashes.</string>
+			<key>developer</key>
+			<string>osquery</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>ParentRecipe</key>
+	<string>com.github.jbaker10.download.osquery</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- switched to `GitHubReleasesInfoProvider` to obtain download URL (also obtains version string as `%version%` which can be used for child recipes)
  - added `%asset_regex%` to ensure only the .pkg is downloaded
- changed `%developer%` in munki recipe from Facebook to osquery
- updated munki recipe `%description%` (pulled from https://osquery.readthedocs.io/)
- linted all modified recipes via `plutil -convert xml1`

Supersedes #13.