### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/AcronisAccess/AcronisAccess.pkg.recipe
+++ b/AcronisAccess/AcronisAccess.pkg.recipe
@@ -62,8 +62,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/EndNote/EndNoteX7.pkg.recipe
+++ b/EndNote/EndNoteX7.pkg.recipe
@@ -66,8 +66,6 @@
           <string>%version%</string>
           <key>id</key>
           <string>%PKG_ID%</string>
-          <key>options</key>
-          <string>purge_ds_store</string>
           <key>chown</key>
           <array>
             <dict>

--- a/EndNote/EndNoteX7Updates.pkg.recipe
+++ b/EndNote/EndNoteX7Updates.pkg.recipe
@@ -76,8 +76,6 @@
                     <!-- Would like to make the ID dynamic -->
                     <key>id</key>
                     <string>com.ThomsonResearchSoft.EndNote</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>endnote_scripts</string>
                     <key>chown</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._