### PR TITLE
Change osquery parent recipe

### DIFF
--- a/osquery/osquery.download.recipe
+++ b/osquery/osquery.download.recipe
@@ -17,6 +17,15 @@
 	<string>0.5.0</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the osquery recipes in the keeleysam-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/osquery/osquery.lanrev.recipe
+++ b/osquery/osquery.lanrev.recipe
@@ -14,7 +14,7 @@
 		<string>latest</string>
 	</dict>
 	<key>ParentRecipe</key>
-	<string>com.github.jbaker10.download.osquery</string>
+	<string>com.github.keeleysam.recipes.osquery.download</string>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
 	<key>Process</key>


### PR DESCRIPTION
The osquery.download and osquery.munki recipes in this repo are similar in function the earlier-created ones in keeleysam-recipes. This PR adjusts your lanrev recipe to use keeleysam's download recipe as a parent.

This consolidation will help simplify search results and lower maintenance effort. Thank you!