### PR TITLE
Accommodate software titles that fail strict verification

### DIFF
--- a/EndNote/EndNoteX7.download.recipe
+++ b/EndNote/EndNoteX7.download.recipe
@@ -41,6 +41,8 @@
         <string>%pathname%/EndNote X7/EndNote X7.app</string>
         <key>requirement</key>
         <string>anchor trusted</string>
+        <key>strict_verification</key>
+        <false/>
       </dict>
     </dict>
   </array>


### PR DESCRIPTION
This PR adds `strict_verification: false` to the `CodeSignatureVerifier` step(s) in one or more of your download recipes.

The next version of AutoPkg will likely change `CodeSignatureVerifier` so that `strict_verification` defaults to true instead of false. Under strict verification, `codesign --strict` rejects apps with specific build anomalies (e.g. `com.apple.FinderInfo`, resource forks) — which currently affect recipes in this repo.

Setting `strict_verification: false` explicitly opts these recipes out of that upcoming default so they keep working after the release. Because `false` is also the *current* default, this change is safe to merge. The recipe is simply being pinned to its existing verification behavior.

To confirm the change works, a comment on this PR includes the verbatim `autopkg run -vv` output showing the recipe still verifies successfully with the change applied.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.